### PR TITLE
Add option to force push to Heroku repository

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -54,7 +54,7 @@ if [ $? -ne 0 ] ; then
   exit 1
 fi
 
-git push heroku HEAD:master
+git push heroku HEAD:master --force
 if [ $? -ne 0 ] ; then
   echo " [!] Failed to git push to heroku"
   restore_orig_netrc

--- a/step.sh
+++ b/step.sh
@@ -54,7 +54,15 @@ if [ $? -ne 0 ] ; then
   exit 1
 fi
 
-git push heroku HEAD:master --force
+if [ "$force_push" == true ] ; then
+  git push heroku HEAD:master --force
+elif [ "$force_push" == false ] ; then
+  git push heroku HEAD:master
+else
+  echo " $force_push variable not set"
+  exit 1
+fi
+
 if [ $? -ne 0 ] ; then
   echo " [!] Failed to git push to heroku"
   restore_orig_netrc

--- a/step.yml
+++ b/step.yml
@@ -49,3 +49,20 @@ inputs:
         Your webapp's Heroku App ID. This is the ID of the App you
         can see on your [Heroku Dashboard](https://dashboard.heroku.com/apps).
       is_required: true
+
+
+  - force_push: "true"
+    opts:
+      title: Force push to Heroku repository?
+      summary: |-
+        If this option is allowed the project will be
+        force-pushed to the Heroku repository.
+      description: |-
+        If this option is allowed the project will be
+        force-pushed to the Heroku repository. This might
+        be necessary if the repository already exists there.
+      is_required: true
+      is_expand: false
+      value_options:
+        - "true"
+        - "false"


### PR DESCRIPTION
When `git push`ing a bitrise repository to Heroku, the `--force` option has to be used if a Heroku repository already exists.

This pull request implements this as an option, which defaults to true (force push). Fixes https://github.com/bitrise-steplib/steps-heroku-deploy/issues/1.