### PR TITLE
fix: Heroku brew package has changed 

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -21,7 +21,7 @@ deps:
   brew:
   - name: git
   - name: wget
-  - name: heroku
+  - name: heroku/brew/heroku
   apt_get:
   - name: git
   - name: wget


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Step is unable to install Heroku CLI via Brew on MacOS as the package location has changed.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->
Resolves: https://github.com/bitrise-steplib/steps-heroku-deploy/issues/7
### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

Replaced the Brew package in the step.yml `deps` section with the new one (from Heroku's documentation https://devcenter.heroku.com/articles/heroku-cli)

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
