### PR TITLE
Update URL for script installing Heroku Toolbelt

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -17,7 +17,7 @@ if [[ "$(uname)" == "Linux" ]] ; then
     echo " (i) Heroku Toolbelt already installed"
   else
     echo " (i) Installing Heroku"
-    wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
+    wget -O- https://cli-assets.heroku.com/install-ubuntu.sh | sh
     if [ $? -ne 0 ] ; then
       echo " [!] Failed to install Heroku Toolbelt!"
       exit 1


### PR DESCRIPTION
This PR updates the URL for the script file which is responsible for installing Heroku Toolbelt, to a working URL.

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The link https://toolbelt.heroku.com/install-ubuntu.sh no longer works, it always responds with 503 (service unavailable). 

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

Heroku Toolbelt install script is now downloaded from cli-assets.heroku.com instead of toolbelt.heroku.com.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
